### PR TITLE
[DW-4199] Replace old SSM policy with new

### DIFF
--- a/terraform/modules/iam-emr/iam.tf
+++ b/terraform/modules/iam-emr/iam.tf
@@ -29,7 +29,7 @@ resource "aws_iam_role_policy_attachment" "emr_for_ec2_attachment" {
 
 resource "aws_iam_role_policy_attachment" "ec2_for_ssm_attachment" {
   role       = aws_iam_role.emr_cb_iam.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonSSMManagedInstanceCore"
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
 }
 
 data "aws_iam_policy_document" "write_s3_cb" {

--- a/terraform/modules/iam-emr/iam.tf
+++ b/terraform/modules/iam-emr/iam.tf
@@ -29,7 +29,7 @@ resource "aws_iam_role_policy_attachment" "emr_for_ec2_attachment" {
 
 resource "aws_iam_role_policy_attachment" "ec2_for_ssm_attachment" {
   role       = aws_iam_role.emr_cb_iam.name
-  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM"
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonSSMManagedInstanceCore"
 }
 
 data "aws_iam_policy_document" "write_s3_cb" {


### PR DESCRIPTION
This policy will soon be deprecated. Please use AmazonSSMManagedInstanceCore policy to enable AWS Systems Manager service core functionality on EC2 instances. For more information see https://docs.aws.amazon.com/systems-manager/latest/userguide/setup-instance-profile.html